### PR TITLE
Add augment system and new AugmentWar game mode

### DIFF
--- a/modules/Plugin/src/daybreak/abilitywar/Commands.java
+++ b/modules/Plugin/src/daybreak/abilitywar/Commands.java
@@ -21,6 +21,7 @@ import daybreak.abilitywar.game.AbstractGame;
 import daybreak.abilitywar.game.AbstractGame.GameTimer;
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.GameManager;
+import daybreak.abilitywar.game.list.augment.AugmentWarGame;
 import daybreak.abilitywar.game.list.mix.synergy.SynergyFactory;
 import daybreak.abilitywar.game.list.mix.synergy.game.SynergyBlackListGUI;
 import daybreak.abilitywar.game.manager.AbilityList;
@@ -125,6 +126,7 @@ public class Commands implements CommandExecutor, TabCompleter {
 								Formatter.formatCommand(command, "start", "게임을 시작시킵니다.", true),
 								Formatter.formatCommand(command, "stop", "게임을 중지시킵니다.", true),
 								Formatter.formatCommand(command, "check", "자신의 능력을 확인합니다.", false),
+								Formatter.formatCommand(command, "augment", "증강 선택 GUI를 엽니다.", false),
 								Formatter.formatCommand(command, "yes", "자신의 능력을 확정합니다.", false),
 								Formatter.formatCommand(command, "no", "자신의 능력을 변경합니다.", false),
 								Formatter.formatCommand(command, "abilities", "능력자 전쟁 능력 목록을 확인합니다.", false),
@@ -204,6 +206,17 @@ public class Commands implements CommandExecutor, TabCompleter {
 				if (GameManager.isGameRunning()) {
 					GameManager.getGame().executeCommand(CommandType.ABILITY_CHECK, sender, command, args, plugin);
 				} else Messager.sendErrorMessage(sender, "게임이 진행되고 있지 않습니다.");
+				return true;
+			}
+		});
+		mainCommand.addSubCommand("augment", new Command(Condition.PLAYER) {
+			@Override
+			protected boolean onCommand(CommandSender sender, String command, String[] args) {
+				if (GameManager.isGameOf(AugmentWarGame.class)) {
+					((AugmentWarGame) GameManager.getGame()).openAugmentGUI((Player) sender);
+				} else {
+					Messager.sendErrorMessage(sender, "증강 능력자 전쟁 게임에서만 사용할 수 있습니다.");
+				}
 				return true;
 			}
 		});

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/AbstractAugment.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/AbstractAugment.java
@@ -1,14 +1,20 @@
 package daybreak.abilitywar.game.augment;
 
 import daybreak.abilitywar.game.AbstractGame.Participant;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-public abstract class AbstractAugment implements Augment {
+public abstract class AbstractAugment implements Augment, Listener {
 
 	private final String key;
 	private final String displayName;
 	private final AugmentRarity rarity;
 	private final String description;
+	private AugmentContext context;
 
 	protected AbstractAugment(@NotNull String key, @NotNull String displayName, @NotNull AugmentRarity rarity, @NotNull String description) {
 		this.key = key;
@@ -40,5 +46,28 @@ public abstract class AbstractAugment implements Augment {
 	@Override
 	public boolean isAvailable(@NotNull AugmentContext context, @NotNull Participant participant) {
 		return !context.hasAugment(participant, this);
+	}
+
+	@Override
+	public final void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
+		this.context = context;
+		context.addAugment(participant, this);
+		onApply(context, participant);
+	}
+
+	protected void onApply(@NotNull AugmentContext context, @NotNull Participant participant) {}
+
+	protected final boolean hasAugment(@Nullable Participant participant) {
+		return context != null && participant != null && context.hasAugment(participant, this);
+	}
+
+	@Nullable
+	protected final Participant getParticipant(@NotNull Player player) {
+		return context != null ? context.getGame().getParticipant(player) : null;
+	}
+
+	protected final void heal(@NotNull Player player, double amount) {
+		final AttributeInstance maxHealth = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+		if (maxHealth != null) player.setHealth(Math.min(maxHealth.getValue(), player.getHealth() + amount));
 	}
 }

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/AbstractAugment.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/AbstractAugment.java
@@ -1,0 +1,44 @@
+package daybreak.abilitywar.game.augment;
+
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class AbstractAugment implements Augment {
+
+	private final String key;
+	private final String displayName;
+	private final AugmentRarity rarity;
+	private final String description;
+
+	protected AbstractAugment(@NotNull String key, @NotNull String displayName, @NotNull AugmentRarity rarity, @NotNull String description) {
+		this.key = key;
+		this.displayName = displayName;
+		this.rarity = rarity;
+		this.description = description;
+	}
+
+	@Override
+	public final String getKey() {
+		return key;
+	}
+
+	@Override
+	public final String getDisplayName() {
+		return displayName;
+	}
+
+	@Override
+	public final AugmentRarity getRarity() {
+		return rarity;
+	}
+
+	@Override
+	public final String getDescription() {
+		return description;
+	}
+
+	@Override
+	public boolean isAvailable(@NotNull AugmentContext context, @NotNull Participant participant) {
+		return !context.hasAugment(participant, this);
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/AbstractAugment.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/AbstractAugment.java
@@ -1,5 +1,6 @@
 package daybreak.abilitywar.game.augment;
 
+import com.google.common.base.Preconditions;
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
@@ -10,37 +11,38 @@ import org.jetbrains.annotations.Nullable;
 
 public abstract class AbstractAugment implements Augment, Listener {
 
-	private final String key;
-	private final String displayName;
-	private final AugmentRarity rarity;
-	private final String description;
+	private final AugmentManifest manifest;
 	private AugmentContext context;
 
-	protected AbstractAugment(@NotNull String key, @NotNull String displayName, @NotNull AugmentRarity rarity, @NotNull String description) {
-		this.key = key;
-		this.displayName = displayName;
-		this.rarity = rarity;
-		this.description = description;
+	protected AbstractAugment() {
+		if (!getClass().isAnnotationPresent(AugmentManifest.class)) {
+			throw new IllegalArgumentException("AugmentManifest가 없는 증강입니다.");
+		}
+		this.manifest = getClass().getAnnotation(AugmentManifest.class);
+		Preconditions.checkNotNull(manifest.key());
+		Preconditions.checkNotNull(manifest.name());
+		Preconditions.checkNotNull(manifest.rarity());
+		Preconditions.checkNotNull(manifest.description());
 	}
 
 	@Override
 	public final String getKey() {
-		return key;
+		return manifest.key();
 	}
 
 	@Override
 	public final String getDisplayName() {
-		return displayName;
+		return manifest.name();
 	}
 
 	@Override
 	public final AugmentRarity getRarity() {
-		return rarity;
+		return manifest.rarity();
 	}
 
 	@Override
 	public final String getDescription() {
-		return description;
+		return manifest.description();
 	}
 
 	@Override

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/Augment.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/Augment.java
@@ -1,0 +1,32 @@
+package daybreak.abilitywar.game.augment;
+
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * 참가자가 선택할 수 있는 하나의 증강입니다.
+ */
+public interface Augment {
+
+	@NotNull
+	String getKey();
+
+	@NotNull
+	String getDisplayName();
+
+	@NotNull
+	AugmentRarity getRarity();
+
+	@NotNull
+	String getDescription();
+
+	/**
+	 * 특정 참가자에게 이미 적용되어 있거나 조건을 만족하지 못하면 false를 반환합니다.
+	 */
+	boolean isAvailable(@NotNull AugmentContext context, @NotNull Participant participant);
+
+	/**
+	 * 선택된 증강 효과를 참가자에게 적용합니다.
+	 */
+	void apply(@NotNull AugmentContext context, @NotNull Participant participant);
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/AugmentContext.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/AugmentContext.java
@@ -1,0 +1,30 @@
+package daybreak.abilitywar.game.augment;
+
+import daybreak.abilitywar.game.AbstractGame;
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+public interface AugmentContext {
+
+	@NotNull
+	AbstractGame getGame();
+
+	@NotNull
+	Collection<Augment> getAugments(@NotNull Participant participant);
+
+	boolean hasAugment(@NotNull Participant participant, @NotNull Augment augment);
+
+	void addAugment(@NotNull Participant participant, @NotNull Augment augment);
+
+	default void addMaxHealth(@NotNull Participant participant, double amount) {
+		final AttributeInstance attribute = participant.getPlayer().getAttribute(Attribute.GENERIC_MAX_HEALTH);
+		if (attribute != null) {
+			attribute.setBaseValue(Math.max(1, attribute.getBaseValue() + amount));
+			participant.getPlayer().setHealth(Math.min(attribute.getValue(), participant.getPlayer().getHealth() + amount));
+		}
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/AugmentFactory.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/AugmentFactory.java
@@ -1,0 +1,118 @@
+package daybreak.abilitywar.game.augment;
+
+import com.google.common.base.Preconditions;
+import daybreak.abilitywar.game.augment.list.AbilityEcho;
+import daybreak.abilitywar.game.augment.list.AbilityOverdrive;
+import daybreak.abilitywar.game.augment.list.ArrowFocus;
+import daybreak.abilitywar.game.augment.list.BattleTrance;
+import daybreak.abilitywar.game.augment.list.Comeback;
+import daybreak.abilitywar.game.augment.list.Executioner;
+import daybreak.abilitywar.game.augment.list.ExtraHeart;
+import daybreak.abilitywar.game.augment.list.GlassCannon;
+import daybreak.abilitywar.game.augment.list.LastStand;
+import daybreak.abilitywar.game.augment.list.PrismaticBody;
+import daybreak.abilitywar.game.augment.list.RaidBoss;
+import daybreak.abilitywar.game.augment.list.SwiftStart;
+import daybreak.abilitywar.game.augment.list.Thornmail;
+import daybreak.abilitywar.game.augment.list.VampiricBlade;
+import daybreak.abilitywar.utils.base.logging.Logger;
+import daybreak.abilitywar.utils.base.reflect.ReflectionUtil;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AugmentFactory {
+
+	private static final Logger logger = Logger.getLogger(AugmentFactory.class);
+	private static final Map<String, AugmentRegistration> usedKeys = new LinkedHashMap<>();
+	private static final Map<Class<? extends Augment>, AugmentRegistration> registeredAugments = new LinkedHashMap<>();
+
+	static {
+		registerAugment(ExtraHeart.class);
+		registerAugment(SwiftStart.class);
+		registerAugment(BattleTrance.class);
+		registerAugment(PrismaticBody.class);
+		registerAugment(GlassCannon.class);
+		registerAugment(VampiricBlade.class);
+		registerAugment(Executioner.class);
+		registerAugment(Comeback.class);
+		registerAugment(ArrowFocus.class);
+		registerAugment(Thornmail.class);
+		registerAugment(LastStand.class);
+		registerAugment(RaidBoss.class);
+		registerAugment(AbilityEcho.class);
+		registerAugment(AbilityOverdrive.class);
+	}
+
+	private AugmentFactory() {}
+
+	public static void registerAugment(Class<? extends Augment> augmentClass) {
+		if (!registeredAugments.containsKey(augmentClass)) {
+			try {
+				final AugmentRegistration registration = new AugmentRegistration(augmentClass);
+				final String key = registration.getManifest().key();
+				if (!usedKeys.containsKey(key)) {
+					registeredAugments.put(registration.getAugmentClass(), registration);
+					usedKeys.put(key, registration);
+				} else {
+					logger.debug("§e" + augmentClass.getName() + " §f증강은 겹치는 키가 있어 등록되지 않았습니다.");
+				}
+			} catch (Exception | ExceptionInInitializerError e) {
+				logger.error("§e" + augmentClass.getName() + " §f증강 등록 중 오류가 발생하였습니다.");
+				e.printStackTrace();
+			}
+		}
+	}
+
+	public static void registerAugment(String className) {
+		try {
+			registerAugment(ReflectionUtil.ClassUtil.forName(className).asSubclass(Augment.class));
+		} catch (ClassNotFoundException e) {
+			logger.debug("§e" + className + " §f클래스는 존재하지 않습니다.");
+		} catch (ClassCastException e) {
+			logger.error("§e" + className + " §f클래스는 Augment를 구현하지 않습니다.");
+		} catch (NoClassDefFoundError e) {
+			logger.debug("§e" + className + " §f클래스를 찾을 수 없습니다.");
+		}
+	}
+
+	public static List<AugmentRegistration> getRegistrations() {
+		return new ArrayList<>(registeredAugments.values());
+	}
+
+	public static AugmentRegistration getByKey(String key) {
+		return usedKeys.get(key);
+	}
+
+	public static class AugmentRegistration {
+		private final Class<? extends Augment> clazz;
+		private final Constructor<? extends Augment> constructor;
+		private final AugmentManifest manifest;
+
+		private AugmentRegistration(Class<? extends Augment> clazz) throws NoSuchMethodException {
+			this.clazz = clazz;
+			this.constructor = clazz.getConstructor();
+			if (!clazz.isAnnotationPresent(AugmentManifest.class)) throw new IllegalArgumentException("AugmentManifest가 없는 증강입니다.");
+			this.manifest = clazz.getAnnotation(AugmentManifest.class);
+			Preconditions.checkNotNull(manifest.key());
+			Preconditions.checkNotNull(manifest.name());
+			Preconditions.checkNotNull(manifest.rarity());
+			Preconditions.checkNotNull(manifest.description());
+		}
+
+		public Class<? extends Augment> getAugmentClass() { return clazz; }
+		public Constructor<? extends Augment> getConstructor() { return constructor; }
+		public AugmentManifest getManifest() { return manifest; }
+
+		public Augment newInstance() {
+			try {
+				return constructor.newInstance();
+			} catch (Exception e) {
+				throw new IllegalStateException("증강 인스턴스를 생성할 수 없습니다: " + clazz.getName(), e);
+			}
+		}
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/AugmentManifest.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/AugmentManifest.java
@@ -1,0 +1,17 @@
+package daybreak.abilitywar.game.augment;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface AugmentManifest {
+	String key();
+	String name();
+	AugmentRarity rarity();
+	String description();
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/AugmentRarity.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/AugmentRarity.java
@@ -1,0 +1,39 @@
+package daybreak.abilitywar.game.augment;
+
+import org.bukkit.ChatColor;
+
+/**
+ * 롤 아레나의 증강 등급처럼 선택지의 희귀도와 기본 가중치를 표현합니다.
+ */
+public enum AugmentRarity {
+
+	SILVER("실버", ChatColor.WHITE, 60),
+	GOLD("골드", ChatColor.GOLD, 30),
+	PRISMATIC("프리즘", ChatColor.LIGHT_PURPLE, 10);
+
+	private final String displayName;
+	private final ChatColor color;
+	private final int defaultWeight;
+
+	AugmentRarity(String displayName, ChatColor color, int defaultWeight) {
+		this.displayName = displayName;
+		this.color = color;
+		this.defaultWeight = defaultWeight;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+
+	public ChatColor getColor() {
+		return color;
+	}
+
+	public int getDefaultWeight() {
+		return defaultWeight;
+	}
+
+	public String format(String text) {
+		return color + text + ChatColor.RESET;
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/AugmentRegistry.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/AugmentRegistry.java
@@ -1,0 +1,42 @@
+package daybreak.abilitywar.game.augment;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AugmentRegistry {
+
+	private final Map<String, Augment> augments = new LinkedHashMap<>();
+
+	public void register(@NotNull Augment augment) {
+		if (augments.containsKey(augment.getKey())) {
+			throw new IllegalArgumentException("Duplicated augment key: " + augment.getKey());
+		}
+		augments.put(augment.getKey(), augment);
+	}
+
+	@Nullable
+	public Augment getByKey(@NotNull String key) {
+		return augments.get(key);
+	}
+
+	@NotNull
+	public Collection<Augment> values() {
+		return Collections.unmodifiableCollection(augments.values());
+	}
+
+	@NotNull
+	public List<Augment> values(@NotNull AugmentRarity rarity) {
+		final List<Augment> result = new ArrayList<>();
+		for (Augment augment : augments.values()) {
+			if (augment.getRarity() == rarity) result.add(augment);
+		}
+		return result;
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/AugmentRegistry.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/AugmentRegistry.java
@@ -1,5 +1,9 @@
 package daybreak.abilitywar.game.augment;
 
+import daybreak.abilitywar.AbilityWar;
+import org.bukkit.Bukkit;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,6 +23,15 @@ public class AugmentRegistry {
 			throw new IllegalArgumentException("Duplicated augment key: " + augment.getKey());
 		}
 		augments.put(augment.getKey(), augment);
+		if (augment instanceof Listener) {
+			Bukkit.getPluginManager().registerEvents((Listener) augment, AbilityWar.getPlugin());
+		}
+	}
+
+	public void unregisterListeners() {
+		for (Augment augment : augments.values()) {
+			if (augment instanceof Listener) HandlerList.unregisterAll((Listener) augment);
+		}
 	}
 
 	@Nullable

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/AugmentSelection.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/AugmentSelection.java
@@ -1,0 +1,60 @@
+package daybreak.abilitywar.game.augment;
+
+import com.google.common.collect.ImmutableList;
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * 참가자에게 보여 줄 증강 선택지를 생성합니다.
+ */
+public class AugmentSelection {
+
+	private final AugmentRegistry registry;
+	private final Random random;
+	private final Map<AugmentRarity, Integer> rarityWeights = new EnumMap<>(AugmentRarity.class);
+
+	public AugmentSelection(@NotNull AugmentRegistry registry, @NotNull Random random) {
+		this.registry = registry;
+		this.random = random;
+		for (AugmentRarity rarity : AugmentRarity.values()) {
+			rarityWeights.put(rarity, rarity.getDefaultWeight());
+		}
+	}
+
+	public void setRarityWeight(@NotNull AugmentRarity rarity, int weight) {
+		rarityWeights.put(rarity, Math.max(0, weight));
+	}
+
+	@NotNull
+	public List<Augment> roll(@NotNull AugmentContext context, @NotNull Participant participant, int amount) {
+		final List<Augment> result = new ArrayList<>();
+		for (int i = 0; i < amount; i++) {
+			final AugmentRarity rarity = selectRarity();
+			final List<Augment> pool = new ArrayList<>();
+			for (Augment augment : registry.values(rarity)) {
+				if (!result.contains(augment) && augment.isAvailable(context, participant)) pool.add(augment);
+			}
+			if (pool.isEmpty()) break;
+			result.add(pool.get(random.nextInt(pool.size())));
+		}
+		return ImmutableList.copyOf(result);
+	}
+
+	private AugmentRarity selectRarity() {
+		int totalWeight = 0;
+		for (int weight : rarityWeights.values()) totalWeight += weight;
+		if (totalWeight <= 0) return AugmentRarity.SILVER;
+		int value = random.nextInt(totalWeight);
+		for (Map.Entry<AugmentRarity, Integer> entry : rarityWeights.entrySet()) {
+			value -= entry.getValue();
+			if (value < 0) return entry.getKey();
+		}
+		return AugmentRarity.SILVER;
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/DefaultAugments.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/DefaultAugments.java
@@ -1,19 +1,5 @@
 package daybreak.abilitywar.game.augment;
 
-import daybreak.abilitywar.game.augment.list.AbilityEcho;
-import daybreak.abilitywar.game.augment.list.AbilityOverdrive;
-import daybreak.abilitywar.game.augment.list.ArrowFocus;
-import daybreak.abilitywar.game.augment.list.BattleTrance;
-import daybreak.abilitywar.game.augment.list.Comeback;
-import daybreak.abilitywar.game.augment.list.Executioner;
-import daybreak.abilitywar.game.augment.list.ExtraHeart;
-import daybreak.abilitywar.game.augment.list.GlassCannon;
-import daybreak.abilitywar.game.augment.list.LastStand;
-import daybreak.abilitywar.game.augment.list.PrismaticBody;
-import daybreak.abilitywar.game.augment.list.RaidBoss;
-import daybreak.abilitywar.game.augment.list.SwiftStart;
-import daybreak.abilitywar.game.augment.list.Thornmail;
-import daybreak.abilitywar.game.augment.list.VampiricBlade;
 import org.bukkit.ChatColor;
 import org.jetbrains.annotations.NotNull;
 
@@ -23,20 +9,9 @@ public final class DefaultAugments {
 
 	public static AugmentRegistry createRegistry() {
 		final AugmentRegistry registry = new AugmentRegistry();
-		registry.register(new ExtraHeart());
-		registry.register(new SwiftStart());
-		registry.register(new BattleTrance());
-		registry.register(new PrismaticBody());
-		registry.register(new GlassCannon());
-		registry.register(new VampiricBlade());
-		registry.register(new Executioner());
-		registry.register(new Comeback());
-		registry.register(new ArrowFocus());
-		registry.register(new Thornmail());
-		registry.register(new LastStand());
-		registry.register(new RaidBoss());
-		registry.register(new AbilityEcho());
-		registry.register(new AbilityOverdrive());
+		for (AugmentFactory.AugmentRegistration registration : AugmentFactory.getRegistrations()) {
+			registry.register(registration.newInstance());
+		}
 		return registry;
 	}
 

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/DefaultAugments.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/DefaultAugments.java
@@ -1,0 +1,53 @@
+package daybreak.abilitywar.game.augment;
+
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import org.bukkit.ChatColor;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+
+public final class DefaultAugments {
+
+	private DefaultAugments() {}
+
+	public static AugmentRegistry createRegistry() {
+		final AugmentRegistry registry = new AugmentRegistry();
+		registry.register(new AbstractAugment("extra_heart", "튼튼한 심장", AugmentRarity.SILVER, "최대 체력이 2 증가합니다.") {
+			@Override
+			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
+				context.addMaxHealth(participant, 2.0);
+				context.addAugment(participant, this);
+			}
+		});
+		registry.register(new AbstractAugment("swift_start", "민첩한 출발", AugmentRarity.SILVER, "이동 속도가 소폭 증가합니다.") {
+			@Override
+			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
+				final AttributeInstance attribute = participant.getPlayer().getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+				if (attribute != null) attribute.setBaseValue(attribute.getBaseValue() * 1.08);
+				context.addAugment(participant, this);
+			}
+		});
+		registry.register(new AbstractAugment("battle_trance", "전투 몰입", AugmentRarity.GOLD, "상시 힘 I 효과를 얻습니다.") {
+			@Override
+			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
+				participant.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.INCREASE_DAMAGE, Integer.MAX_VALUE, 0, true, false));
+				context.addAugment(participant, this);
+			}
+		});
+		registry.register(new AbstractAugment("prismatic_body", "프리즘 육체", AugmentRarity.PRISMATIC, "최대 체력이 6 증가하고 재생 I 효과를 얻습니다.") {
+			@Override
+			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
+				context.addMaxHealth(participant, 6.0);
+				participant.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, Integer.MAX_VALUE, 0, true, false));
+				context.addAugment(participant, this);
+			}
+		});
+		return registry;
+	}
+
+	public static String format(@NotNull Augment augment) {
+		return augment.getRarity().format("[" + augment.getRarity().getDisplayName() + "] ") + ChatColor.WHITE + augment.getDisplayName() + ChatColor.GRAY + " - " + augment.getDescription();
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/DefaultAugments.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/DefaultAugments.java
@@ -1,11 +1,20 @@
 package daybreak.abilitywar.game.augment;
 
-import daybreak.abilitywar.game.AbstractGame.Participant;
+import daybreak.abilitywar.game.augment.list.AbilityEcho;
+import daybreak.abilitywar.game.augment.list.AbilityOverdrive;
+import daybreak.abilitywar.game.augment.list.ArrowFocus;
+import daybreak.abilitywar.game.augment.list.BattleTrance;
+import daybreak.abilitywar.game.augment.list.Comeback;
+import daybreak.abilitywar.game.augment.list.Executioner;
+import daybreak.abilitywar.game.augment.list.ExtraHeart;
+import daybreak.abilitywar.game.augment.list.GlassCannon;
+import daybreak.abilitywar.game.augment.list.LastStand;
+import daybreak.abilitywar.game.augment.list.PrismaticBody;
+import daybreak.abilitywar.game.augment.list.RaidBoss;
+import daybreak.abilitywar.game.augment.list.SwiftStart;
+import daybreak.abilitywar.game.augment.list.Thornmail;
+import daybreak.abilitywar.game.augment.list.VampiricBlade;
 import org.bukkit.ChatColor;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.attribute.AttributeInstance;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
 public final class DefaultAugments {
@@ -14,113 +23,20 @@ public final class DefaultAugments {
 
 	public static AugmentRegistry createRegistry() {
 		final AugmentRegistry registry = new AugmentRegistry();
-		registry.register(new AbstractAugment("extra_heart", "튼튼한 심장", AugmentRarity.SILVER, "최대 체력이 2 증가합니다.") {
-			@Override
-			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
-				context.addMaxHealth(participant, 2.0);
-				context.addAugment(participant, this);
-			}
-		});
-		registry.register(new AbstractAugment("swift_start", "민첩한 출발", AugmentRarity.SILVER, "이동 속도가 소폭 증가합니다.") {
-			@Override
-			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
-				final AttributeInstance attribute = participant.getPlayer().getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
-				if (attribute != null) attribute.setBaseValue(attribute.getBaseValue() * 1.08);
-				context.addAugment(participant, this);
-			}
-		});
-		registry.register(new AbstractAugment("battle_trance", "전투 몰입", AugmentRarity.GOLD, "상시 힘 I 효과를 얻습니다.") {
-			@Override
-			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
-				participant.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.INCREASE_DAMAGE, Integer.MAX_VALUE, 0, true, false));
-				context.addAugment(participant, this);
-			}
-		});
-		registry.register(new AbstractAugment("prismatic_body", "프리즘 육체", AugmentRarity.PRISMATIC, "최대 체력이 6 증가하고 재생 I 효과를 얻습니다.") {
-			@Override
-			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
-				context.addMaxHealth(participant, 6.0);
-				participant.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, Integer.MAX_VALUE, 0, true, false));
-				context.addAugment(participant, this);
-			}
-		});
-
-		registry.register(new AbstractAugment("glass_cannon", "양날의 검", AugmentRarity.GOLD, "주는 피해가 25% 증가하지만 받는 피해도 15% 증가합니다.") {
-			@Override
-			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
-				context.addAugment(participant, this);
-			}
-		});
-		registry.register(new AbstractAugment("vampiric_blade", "흡혈 칼날", AugmentRarity.GOLD, "플레이어에게 준 피해의 20%만큼 체력을 회복합니다.") {
-			@Override
-			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
-				context.addAugment(participant, this);
-			}
-		});
-		registry.register(new AbstractAugment("executioner", "처형자", AugmentRarity.GOLD, "체력이 30% 이하인 적에게 주는 피해가 30% 증가합니다.") {
-			@Override
-			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
-				context.addAugment(participant, this);
-			}
-		});
-		registry.register(new AbstractAugment("comeback", "역전의 기회", AugmentRarity.SILVER, "피격 후 체력이 40% 이하라면 잠시 재생과 저항을 얻습니다.") {
-			@Override
-			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
-				context.addAugment(participant, this);
-			}
-		});
-		registry.register(new AbstractAugment("arrow_focus", "저격수의 집중", AugmentRarity.SILVER, "10블록 이상 떨어진 화살 피해가 35% 증가합니다.") {
-			@Override
-			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
-				context.addAugment(participant, this);
-			}
-		});
-		registry.register(new AbstractAugment("thornmail", "가시 갑옷", AugmentRarity.GOLD, "근접 피해를 받으면 공격자에게 피해의 20%를 반사합니다.") {
-			@Override
-			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
-				context.addAugment(participant, this);
-			}
-		});
-		registry.register(new AbstractAugment("last_stand", "최후의 저항", AugmentRarity.PRISMATIC, "죽음에 이르는 피해를 한 번 버티고 5초간 강해집니다.") {
-			@Override
-			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
-				context.addAugment(participant, this);
-			}
-		});
-		registry.register(new AbstractAugment("raid_boss", "레이드 보스", AugmentRarity.PRISMATIC, "최대 체력이 8 증가하지만 이동 속도가 감소합니다.") {
-			@Override
-			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
-				context.addMaxHealth(participant, 8.0);
-				final AttributeInstance attribute = participant.getPlayer().getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
-				if (attribute != null) attribute.setBaseValue(attribute.getBaseValue() * 0.92);
-				context.addAugment(participant, this);
-			}
-		});
-		registry.register(new AbstractAugment("ability_echo", "능력 메아리", AugmentRarity.GOLD, "능력 쿨타임이 끝날 때 5초간 신속과 힘을 얻습니다.") {
-			@Override
-			public boolean isAvailable(@NotNull AugmentContext context, @NotNull Participant participant) {
-				return super.isAvailable(context, participant) && participant.hasAbility();
-			}
-
-			@Override
-			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
-				context.addAugment(participant, this);
-			}
-		});
-		registry.register(new AbstractAugment("ability_overdrive", "능력 과부하", AugmentRarity.PRISMATIC, "능력이 있다면 최대 체력과 이동 속도가 증가합니다.") {
-			@Override
-			public boolean isAvailable(@NotNull AugmentContext context, @NotNull Participant participant) {
-				return super.isAvailable(context, participant) && participant.hasAbility();
-			}
-
-			@Override
-			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
-				context.addMaxHealth(participant, 4.0);
-				final AttributeInstance attribute = participant.getPlayer().getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
-				if (attribute != null) attribute.setBaseValue(attribute.getBaseValue() * 1.10);
-				context.addAugment(participant, this);
-			}
-		});
+		registry.register(new ExtraHeart());
+		registry.register(new SwiftStart());
+		registry.register(new BattleTrance());
+		registry.register(new PrismaticBody());
+		registry.register(new GlassCannon());
+		registry.register(new VampiricBlade());
+		registry.register(new Executioner());
+		registry.register(new Comeback());
+		registry.register(new ArrowFocus());
+		registry.register(new Thornmail());
+		registry.register(new LastStand());
+		registry.register(new RaidBoss());
+		registry.register(new AbilityEcho());
+		registry.register(new AbilityOverdrive());
 		return registry;
 	}
 

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/DefaultAugments.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/DefaultAugments.java
@@ -44,6 +44,83 @@ public final class DefaultAugments {
 				context.addAugment(participant, this);
 			}
 		});
+
+		registry.register(new AbstractAugment("glass_cannon", "양날의 검", AugmentRarity.GOLD, "주는 피해가 25% 증가하지만 받는 피해도 15% 증가합니다.") {
+			@Override
+			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
+				context.addAugment(participant, this);
+			}
+		});
+		registry.register(new AbstractAugment("vampiric_blade", "흡혈 칼날", AugmentRarity.GOLD, "플레이어에게 준 피해의 20%만큼 체력을 회복합니다.") {
+			@Override
+			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
+				context.addAugment(participant, this);
+			}
+		});
+		registry.register(new AbstractAugment("executioner", "처형자", AugmentRarity.GOLD, "체력이 30% 이하인 적에게 주는 피해가 30% 증가합니다.") {
+			@Override
+			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
+				context.addAugment(participant, this);
+			}
+		});
+		registry.register(new AbstractAugment("comeback", "역전의 기회", AugmentRarity.SILVER, "피격 후 체력이 40% 이하라면 잠시 재생과 저항을 얻습니다.") {
+			@Override
+			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
+				context.addAugment(participant, this);
+			}
+		});
+		registry.register(new AbstractAugment("arrow_focus", "저격수의 집중", AugmentRarity.SILVER, "10블록 이상 떨어진 화살 피해가 35% 증가합니다.") {
+			@Override
+			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
+				context.addAugment(participant, this);
+			}
+		});
+		registry.register(new AbstractAugment("thornmail", "가시 갑옷", AugmentRarity.GOLD, "근접 피해를 받으면 공격자에게 피해의 20%를 반사합니다.") {
+			@Override
+			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
+				context.addAugment(participant, this);
+			}
+		});
+		registry.register(new AbstractAugment("last_stand", "최후의 저항", AugmentRarity.PRISMATIC, "죽음에 이르는 피해를 한 번 버티고 5초간 강해집니다.") {
+			@Override
+			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
+				context.addAugment(participant, this);
+			}
+		});
+		registry.register(new AbstractAugment("raid_boss", "레이드 보스", AugmentRarity.PRISMATIC, "최대 체력이 8 증가하지만 이동 속도가 감소합니다.") {
+			@Override
+			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
+				context.addMaxHealth(participant, 8.0);
+				final AttributeInstance attribute = participant.getPlayer().getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+				if (attribute != null) attribute.setBaseValue(attribute.getBaseValue() * 0.92);
+				context.addAugment(participant, this);
+			}
+		});
+		registry.register(new AbstractAugment("ability_echo", "능력 메아리", AugmentRarity.GOLD, "능력 쿨타임이 끝날 때 5초간 신속과 힘을 얻습니다.") {
+			@Override
+			public boolean isAvailable(@NotNull AugmentContext context, @NotNull Participant participant) {
+				return super.isAvailable(context, participant) && participant.hasAbility();
+			}
+
+			@Override
+			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
+				context.addAugment(participant, this);
+			}
+		});
+		registry.register(new AbstractAugment("ability_overdrive", "능력 과부하", AugmentRarity.PRISMATIC, "능력이 있다면 최대 체력과 이동 속도가 증가합니다.") {
+			@Override
+			public boolean isAvailable(@NotNull AugmentContext context, @NotNull Participant participant) {
+				return super.isAvailable(context, participant) && participant.hasAbility();
+			}
+
+			@Override
+			public void apply(@NotNull AugmentContext context, @NotNull Participant participant) {
+				context.addMaxHealth(participant, 4.0);
+				final AttributeInstance attribute = participant.getPlayer().getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+				if (attribute != null) attribute.setBaseValue(attribute.getBaseValue() * 1.10);
+				context.addAugment(participant, this);
+			}
+		});
 		return registry;
 	}
 

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/ParticipantAugments.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/ParticipantAugments.java
@@ -37,6 +37,16 @@ public class ParticipantAugments implements AugmentContext {
 		return participantAugments != null && participantAugments.contains(augment);
 	}
 
+	public boolean hasAugment(@NotNull Participant participant, @NotNull String key) {
+		final Set<Augment> participantAugments = augments.get(participant);
+		if (participantAugments != null) {
+			for (Augment augment : participantAugments) {
+				if (augment.getKey().equals(key)) return true;
+			}
+		}
+		return false;
+	}
+
 	@Override
 	public void addAugment(@NotNull Participant participant, @NotNull Augment augment) {
 		Set<Augment> participantAugments = augments.get(participant);

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/ParticipantAugments.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/ParticipantAugments.java
@@ -1,0 +1,49 @@
+package daybreak.abilitywar.game.augment;
+
+import daybreak.abilitywar.game.AbstractGame;
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class ParticipantAugments implements AugmentContext {
+
+	private final AbstractGame game;
+	private final Map<Participant, Set<Augment>> augments = new LinkedHashMap<>();
+
+	public ParticipantAugments(@NotNull AbstractGame game) {
+		this.game = game;
+	}
+
+	@Override
+	public AbstractGame getGame() {
+		return game;
+	}
+
+	@Override
+	public Collection<Augment> getAugments(@NotNull Participant participant) {
+		final Set<Augment> participantAugments = augments.get(participant);
+		return participantAugments != null ? Collections.unmodifiableSet(participantAugments) : Collections.<Augment>emptySet();
+	}
+
+	@Override
+	public boolean hasAugment(@NotNull Participant participant, @NotNull Augment augment) {
+		final Set<Augment> participantAugments = augments.get(participant);
+		return participantAugments != null && participantAugments.contains(augment);
+	}
+
+	@Override
+	public void addAugment(@NotNull Participant participant, @NotNull Augment augment) {
+		Set<Augment> participantAugments = augments.get(participant);
+		if (participantAugments == null) {
+			participantAugments = new LinkedHashSet<>();
+			augments.put(participant, participantAugments);
+		}
+		participantAugments.add(augment);
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/AbilityEcho.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/AbilityEcho.java
@@ -1,0 +1,22 @@
+package daybreak.abilitywar.game.augment.list;
+
+import daybreak.abilitywar.ability.event.AbilityCooldownEndEvent;
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentContext;
+import daybreak.abilitywar.game.augment.AugmentRarity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+
+public class AbilityEcho extends AbstractAugment {
+	public AbilityEcho() { super("ability_echo", "능력 메아리", AugmentRarity.GOLD, "능력 쿨타임이 끝날 때 5초간 신속과 힘을 얻습니다."); }
+	@Override public boolean isAvailable(@NotNull AugmentContext context, @NotNull Participant participant) { return super.isAvailable(context, participant) && participant.hasAbility(); }
+	@EventHandler public void onAbilityCooldownEnd(AbilityCooldownEndEvent event) {
+		if (hasAugment(event.getParticipant())) {
+			event.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 100, 0, true, false));
+			event.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.INCREASE_DAMAGE, 100, 0, true, false));
+		}
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/AbilityEcho.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/AbilityEcho.java
@@ -3,6 +3,7 @@ package daybreak.abilitywar.game.augment.list;
 import daybreak.abilitywar.ability.event.AbilityCooldownEndEvent;
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentManifest;
 import daybreak.abilitywar.game.augment.AugmentContext;
 import daybreak.abilitywar.game.augment.AugmentRarity;
 import org.bukkit.event.EventHandler;
@@ -10,8 +11,8 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
+@AugmentManifest(key = "ability_echo", name = "능력 메아리", rarity = AugmentRarity.GOLD, description = "능력 쿨타임이 끝날 때 5초간 신속과 힘을 얻습니다.")
 public class AbilityEcho extends AbstractAugment {
-	public AbilityEcho() { super("ability_echo", "능력 메아리", AugmentRarity.GOLD, "능력 쿨타임이 끝날 때 5초간 신속과 힘을 얻습니다."); }
 	@Override public boolean isAvailable(@NotNull AugmentContext context, @NotNull Participant participant) { return super.isAvailable(context, participant) && participant.hasAbility(); }
 	@EventHandler public void onAbilityCooldownEnd(AbilityCooldownEndEvent event) {
 		if (hasAugment(event.getParticipant())) {

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/AbilityOverdrive.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/AbilityOverdrive.java
@@ -1,0 +1,19 @@
+package daybreak.abilitywar.game.augment.list;
+
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentContext;
+import daybreak.abilitywar.game.augment.AugmentRarity;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.jetbrains.annotations.NotNull;
+
+public class AbilityOverdrive extends AbstractAugment {
+	public AbilityOverdrive() { super("ability_overdrive", "능력 과부하", AugmentRarity.PRISMATIC, "능력이 있다면 최대 체력과 이동 속도가 증가합니다."); }
+	@Override public boolean isAvailable(@NotNull AugmentContext context, @NotNull Participant participant) { return super.isAvailable(context, participant) && participant.hasAbility(); }
+	@Override protected void onApply(@NotNull AugmentContext context, @NotNull Participant participant) {
+		context.addMaxHealth(participant, 4.0);
+		final AttributeInstance attribute = participant.getPlayer().getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+		if (attribute != null) attribute.setBaseValue(attribute.getBaseValue() * 1.10);
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/AbilityOverdrive.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/AbilityOverdrive.java
@@ -2,14 +2,15 @@ package daybreak.abilitywar.game.augment.list;
 
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentManifest;
 import daybreak.abilitywar.game.augment.AugmentContext;
 import daybreak.abilitywar.game.augment.AugmentRarity;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.jetbrains.annotations.NotNull;
 
+@AugmentManifest(key = "ability_overdrive", name = "능력 과부하", rarity = AugmentRarity.PRISMATIC, description = "능력이 있다면 최대 체력과 이동 속도가 증가합니다.")
 public class AbilityOverdrive extends AbstractAugment {
-	public AbilityOverdrive() { super("ability_overdrive", "능력 과부하", AugmentRarity.PRISMATIC, "능력이 있다면 최대 체력과 이동 속도가 증가합니다."); }
 	@Override public boolean isAvailable(@NotNull AugmentContext context, @NotNull Participant participant) { return super.isAvailable(context, participant) && participant.hasAbility(); }
 	@Override protected void onApply(@NotNull AugmentContext context, @NotNull Participant participant) {
 		context.addMaxHealth(participant, 4.0);

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/ArrowFocus.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/ArrowFocus.java
@@ -2,6 +2,7 @@ package daybreak.abilitywar.game.augment.list;
 
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentManifest;
 import daybreak.abilitywar.game.augment.AugmentRarity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -9,8 +10,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.projectiles.ProjectileSource;
 
+@AugmentManifest(key = "arrow_focus", name = "저격수의 집중", rarity = AugmentRarity.SILVER, description = "10블록 이상 떨어진 화살 피해가 35% 증가합니다.")
 public class ArrowFocus extends AbstractAugment {
-	public ArrowFocus() { super("arrow_focus", "저격수의 집중", AugmentRarity.SILVER, "10블록 이상 떨어진 화살 피해가 35% 증가합니다."); }
 	@EventHandler(ignoreCancelled = true) public void onDamage(EntityDamageByEntityEvent event) {
 		if (event.getDamager() instanceof Projectile) {
 			final ProjectileSource shooter = ((Projectile) event.getDamager()).getShooter();

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/ArrowFocus.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/ArrowFocus.java
@@ -1,0 +1,26 @@
+package daybreak.abilitywar.game.augment.list;
+
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentRarity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.projectiles.ProjectileSource;
+
+public class ArrowFocus extends AbstractAugment {
+	public ArrowFocus() { super("arrow_focus", "저격수의 집중", AugmentRarity.SILVER, "10블록 이상 떨어진 화살 피해가 35% 증가합니다."); }
+	@EventHandler(ignoreCancelled = true) public void onDamage(EntityDamageByEntityEvent event) {
+		if (event.getDamager() instanceof Projectile) {
+			final ProjectileSource shooter = ((Projectile) event.getDamager()).getShooter();
+			if (shooter instanceof Player) {
+				final Participant damager = getParticipant((Player) shooter);
+				if (hasAugment(damager)) {
+					final double distanceSquared = damager.getPlayer().getLocation().distanceSquared(event.getEntity().getLocation());
+					if (distanceSquared >= 100) event.setDamage(event.getDamage() * 1.35);
+				}
+			}
+		}
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/BattleTrance.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/BattleTrance.java
@@ -1,0 +1,16 @@
+package daybreak.abilitywar.game.augment.list;
+
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentContext;
+import daybreak.abilitywar.game.augment.AugmentRarity;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+
+public class BattleTrance extends AbstractAugment {
+	public BattleTrance() { super("battle_trance", "전투 몰입", AugmentRarity.GOLD, "상시 힘 I 효과를 얻습니다."); }
+	@Override protected void onApply(@NotNull AugmentContext context, @NotNull Participant participant) {
+		participant.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.INCREASE_DAMAGE, Integer.MAX_VALUE, 0, true, false));
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/BattleTrance.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/BattleTrance.java
@@ -2,14 +2,15 @@ package daybreak.abilitywar.game.augment.list;
 
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentManifest;
 import daybreak.abilitywar.game.augment.AugmentContext;
 import daybreak.abilitywar.game.augment.AugmentRarity;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
+@AugmentManifest(key = "battle_trance", name = "전투 몰입", rarity = AugmentRarity.GOLD, description = "상시 힘 I 효과를 얻습니다.")
 public class BattleTrance extends AbstractAugment {
-	public BattleTrance() { super("battle_trance", "전투 몰입", AugmentRarity.GOLD, "상시 힘 I 효과를 얻습니다."); }
 	@Override protected void onApply(@NotNull AugmentContext context, @NotNull Participant participant) {
 		participant.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.INCREASE_DAMAGE, Integer.MAX_VALUE, 0, true, false));
 	}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/Comeback.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/Comeback.java
@@ -1,0 +1,26 @@
+package daybreak.abilitywar.game.augment.list;
+
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentRarity;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+public class Comeback extends AbstractAugment {
+	public Comeback() { super("comeback", "역전의 기회", AugmentRarity.SILVER, "피격 후 체력이 40% 이하라면 잠시 재생과 저항을 얻습니다."); }
+	@EventHandler(ignoreCancelled = true) public void onDamage(EntityDamageEvent event) {
+		if (!(event.getEntity() instanceof Player)) return;
+		final Participant participant = getParticipant((Player) event.getEntity());
+		if (!hasAugment(participant)) return;
+		final AttributeInstance maxHealth = participant.getPlayer().getAttribute(Attribute.GENERIC_MAX_HEALTH);
+		if (maxHealth != null && participant.getPlayer().getHealth() - event.getFinalDamage() <= maxHealth.getValue() * 0.40) {
+			participant.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, 80, 0, true, false));
+			participant.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 80, 0, true, false));
+		}
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/Comeback.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/Comeback.java
@@ -2,6 +2,7 @@ package daybreak.abilitywar.game.augment.list;
 
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentManifest;
 import daybreak.abilitywar.game.augment.AugmentRarity;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
@@ -11,8 +12,8 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+@AugmentManifest(key = "comeback", name = "역전의 기회", rarity = AugmentRarity.SILVER, description = "피격 후 체력이 40% 이하라면 잠시 재생과 저항을 얻습니다.")
 public class Comeback extends AbstractAugment {
-	public Comeback() { super("comeback", "역전의 기회", AugmentRarity.SILVER, "피격 후 체력이 40% 이하라면 잠시 재생과 저항을 얻습니다."); }
 	@EventHandler(ignoreCancelled = true) public void onDamage(EntityDamageEvent event) {
 		if (!(event.getEntity() instanceof Player)) return;
 		final Participant participant = getParticipant((Player) event.getEntity());

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/Executioner.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/Executioner.java
@@ -2,6 +2,7 @@ package daybreak.abilitywar.game.augment.list;
 
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentManifest;
 import daybreak.abilitywar.game.augment.AugmentRarity;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
@@ -10,8 +11,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 
+@AugmentManifest(key = "executioner", name = "처형자", rarity = AugmentRarity.GOLD, description = "체력이 30% 이하인 적에게 주는 피해가 30% 증가합니다.")
 public class Executioner extends AbstractAugment {
-	public Executioner() { super("executioner", "처형자", AugmentRarity.GOLD, "체력이 30% 이하인 적에게 주는 피해가 30% 증가합니다."); }
 	@EventHandler(ignoreCancelled = true) public void onDamage(EntityDamageByEntityEvent event) {
 		if (event.getDamager() instanceof Player && event.getEntity() instanceof LivingEntity) {
 			final Participant damager = getParticipant((Player) event.getDamager());

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/Executioner.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/Executioner.java
@@ -1,0 +1,23 @@
+package daybreak.abilitywar.game.augment.list;
+
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentRarity;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+
+public class Executioner extends AbstractAugment {
+	public Executioner() { super("executioner", "처형자", AugmentRarity.GOLD, "체력이 30% 이하인 적에게 주는 피해가 30% 증가합니다."); }
+	@EventHandler(ignoreCancelled = true) public void onDamage(EntityDamageByEntityEvent event) {
+		if (event.getDamager() instanceof Player && event.getEntity() instanceof LivingEntity) {
+			final Participant damager = getParticipant((Player) event.getDamager());
+			final LivingEntity target = (LivingEntity) event.getEntity();
+			final AttributeInstance maxHealth = target.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+			if (hasAugment(damager) && maxHealth != null && target.getHealth() <= maxHealth.getValue() * 0.30) event.setDamage(event.getDamage() * 1.30);
+		}
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/ExtraHeart.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/ExtraHeart.java
@@ -2,11 +2,12 @@ package daybreak.abilitywar.game.augment.list;
 
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentManifest;
 import daybreak.abilitywar.game.augment.AugmentContext;
 import daybreak.abilitywar.game.augment.AugmentRarity;
 import org.jetbrains.annotations.NotNull;
 
+@AugmentManifest(key = "extra_heart", name = "튼튼한 심장", rarity = AugmentRarity.SILVER, description = "최대 체력이 2 증가합니다.")
 public class ExtraHeart extends AbstractAugment {
-	public ExtraHeart() { super("extra_heart", "튼튼한 심장", AugmentRarity.SILVER, "최대 체력이 2 증가합니다."); }
 	@Override protected void onApply(@NotNull AugmentContext context, @NotNull Participant participant) { context.addMaxHealth(participant, 2.0); }
 }

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/ExtraHeart.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/ExtraHeart.java
@@ -1,0 +1,12 @@
+package daybreak.abilitywar.game.augment.list;
+
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentContext;
+import daybreak.abilitywar.game.augment.AugmentRarity;
+import org.jetbrains.annotations.NotNull;
+
+public class ExtraHeart extends AbstractAugment {
+	public ExtraHeart() { super("extra_heart", "튼튼한 심장", AugmentRarity.SILVER, "최대 체력이 2 증가합니다."); }
+	@Override protected void onApply(@NotNull AugmentContext context, @NotNull Participant participant) { context.addMaxHealth(participant, 2.0); }
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/GlassCannon.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/GlassCannon.java
@@ -2,13 +2,14 @@ package daybreak.abilitywar.game.augment.list;
 
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentManifest;
 import daybreak.abilitywar.game.augment.AugmentRarity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 
+@AugmentManifest(key = "glass_cannon", name = "양날의 검", rarity = AugmentRarity.GOLD, description = "주는 피해가 25% 증가하지만 받는 피해도 15% 증가합니다.")
 public class GlassCannon extends AbstractAugment {
-	public GlassCannon() { super("glass_cannon", "양날의 검", AugmentRarity.GOLD, "주는 피해가 25% 증가하지만 받는 피해도 15% 증가합니다."); }
 	@EventHandler(ignoreCancelled = true) public void onDamage(EntityDamageByEntityEvent event) {
 		final Participant damager = event.getDamager() instanceof Player ? getParticipant((Player) event.getDamager()) : null;
 		final Participant victim = event.getEntity() instanceof Player ? getParticipant((Player) event.getEntity()) : null;

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/GlassCannon.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/GlassCannon.java
@@ -1,0 +1,18 @@
+package daybreak.abilitywar.game.augment.list;
+
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentRarity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+
+public class GlassCannon extends AbstractAugment {
+	public GlassCannon() { super("glass_cannon", "양날의 검", AugmentRarity.GOLD, "주는 피해가 25% 증가하지만 받는 피해도 15% 증가합니다."); }
+	@EventHandler(ignoreCancelled = true) public void onDamage(EntityDamageByEntityEvent event) {
+		final Participant damager = event.getDamager() instanceof Player ? getParticipant((Player) event.getDamager()) : null;
+		final Participant victim = event.getEntity() instanceof Player ? getParticipant((Player) event.getEntity()) : null;
+		if (hasAugment(damager)) event.setDamage(event.getDamage() * 1.25);
+		if (hasAugment(victim)) event.setDamage(event.getDamage() * 1.15);
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/LastStand.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/LastStand.java
@@ -1,0 +1,32 @@
+package daybreak.abilitywar.game.augment.list;
+
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentRarity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class LastStand extends AbstractAugment {
+	private final Set<UUID> used = new HashSet<>();
+	public LastStand() { super("last_stand", "최후의 저항", AugmentRarity.PRISMATIC, "죽음에 이르는 피해를 한 번 버티고 5초간 강해집니다."); }
+	@EventHandler(ignoreCancelled = true) public void onDamage(EntityDamageEvent event) {
+		if (!(event.getEntity() instanceof Player)) return;
+		final Player player = (Player) event.getEntity();
+		final Participant participant = getParticipant(player);
+		if (hasAugment(participant) && !used.contains(player.getUniqueId()) && player.getHealth() - event.getFinalDamage() <= 0) {
+			event.setCancelled(true);
+			used.add(player.getUniqueId());
+			player.setHealth(1.0);
+			player.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 100, 1, true, false));
+			player.addPotionEffect(new PotionEffect(PotionEffectType.INCREASE_DAMAGE, 100, 1, true, false));
+			player.sendMessage("§d[증강] §f최후의 저항이 발동했습니다!");
+		}
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/LastStand.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/LastStand.java
@@ -2,6 +2,7 @@ package daybreak.abilitywar.game.augment.list;
 
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentManifest;
 import daybreak.abilitywar.game.augment.AugmentRarity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -13,9 +14,9 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+@AugmentManifest(key = "last_stand", name = "최후의 저항", rarity = AugmentRarity.PRISMATIC, description = "죽음에 이르는 피해를 한 번 버티고 5초간 강해집니다.")
 public class LastStand extends AbstractAugment {
 	private final Set<UUID> used = new HashSet<>();
-	public LastStand() { super("last_stand", "최후의 저항", AugmentRarity.PRISMATIC, "죽음에 이르는 피해를 한 번 버티고 5초간 강해집니다."); }
 	@EventHandler(ignoreCancelled = true) public void onDamage(EntityDamageEvent event) {
 		if (!(event.getEntity() instanceof Player)) return;
 		final Player player = (Player) event.getEntity();

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/PrismaticBody.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/PrismaticBody.java
@@ -1,0 +1,17 @@
+package daybreak.abilitywar.game.augment.list;
+
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentContext;
+import daybreak.abilitywar.game.augment.AugmentRarity;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+
+public class PrismaticBody extends AbstractAugment {
+	public PrismaticBody() { super("prismatic_body", "프리즘 육체", AugmentRarity.PRISMATIC, "최대 체력이 6 증가하고 재생 I 효과를 얻습니다."); }
+	@Override protected void onApply(@NotNull AugmentContext context, @NotNull Participant participant) {
+		context.addMaxHealth(participant, 6.0);
+		participant.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, Integer.MAX_VALUE, 0, true, false));
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/PrismaticBody.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/PrismaticBody.java
@@ -2,14 +2,15 @@ package daybreak.abilitywar.game.augment.list;
 
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentManifest;
 import daybreak.abilitywar.game.augment.AugmentContext;
 import daybreak.abilitywar.game.augment.AugmentRarity;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
+@AugmentManifest(key = "prismatic_body", name = "프리즘 육체", rarity = AugmentRarity.PRISMATIC, description = "최대 체력이 6 증가하고 재생 I 효과를 얻습니다.")
 public class PrismaticBody extends AbstractAugment {
-	public PrismaticBody() { super("prismatic_body", "프리즘 육체", AugmentRarity.PRISMATIC, "최대 체력이 6 증가하고 재생 I 효과를 얻습니다."); }
 	@Override protected void onApply(@NotNull AugmentContext context, @NotNull Participant participant) {
 		context.addMaxHealth(participant, 6.0);
 		participant.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, Integer.MAX_VALUE, 0, true, false));

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/RaidBoss.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/RaidBoss.java
@@ -1,0 +1,18 @@
+package daybreak.abilitywar.game.augment.list;
+
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentContext;
+import daybreak.abilitywar.game.augment.AugmentRarity;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.jetbrains.annotations.NotNull;
+
+public class RaidBoss extends AbstractAugment {
+	public RaidBoss() { super("raid_boss", "레이드 보스", AugmentRarity.PRISMATIC, "최대 체력이 8 증가하지만 이동 속도가 감소합니다."); }
+	@Override protected void onApply(@NotNull AugmentContext context, @NotNull Participant participant) {
+		context.addMaxHealth(participant, 8.0);
+		final AttributeInstance attribute = participant.getPlayer().getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+		if (attribute != null) attribute.setBaseValue(attribute.getBaseValue() * 0.92);
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/RaidBoss.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/RaidBoss.java
@@ -2,14 +2,15 @@ package daybreak.abilitywar.game.augment.list;
 
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentManifest;
 import daybreak.abilitywar.game.augment.AugmentContext;
 import daybreak.abilitywar.game.augment.AugmentRarity;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.jetbrains.annotations.NotNull;
 
+@AugmentManifest(key = "raid_boss", name = "레이드 보스", rarity = AugmentRarity.PRISMATIC, description = "최대 체력이 8 증가하지만 이동 속도가 감소합니다.")
 public class RaidBoss extends AbstractAugment {
-	public RaidBoss() { super("raid_boss", "레이드 보스", AugmentRarity.PRISMATIC, "최대 체력이 8 증가하지만 이동 속도가 감소합니다."); }
 	@Override protected void onApply(@NotNull AugmentContext context, @NotNull Participant participant) {
 		context.addMaxHealth(participant, 8.0);
 		final AttributeInstance attribute = participant.getPlayer().getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/SwiftStart.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/SwiftStart.java
@@ -1,0 +1,17 @@
+package daybreak.abilitywar.game.augment.list;
+
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentContext;
+import daybreak.abilitywar.game.augment.AugmentRarity;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.jetbrains.annotations.NotNull;
+
+public class SwiftStart extends AbstractAugment {
+	public SwiftStart() { super("swift_start", "민첩한 출발", AugmentRarity.SILVER, "이동 속도가 소폭 증가합니다."); }
+	@Override protected void onApply(@NotNull AugmentContext context, @NotNull Participant participant) {
+		final AttributeInstance attribute = participant.getPlayer().getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+		if (attribute != null) attribute.setBaseValue(attribute.getBaseValue() * 1.08);
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/SwiftStart.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/SwiftStart.java
@@ -2,14 +2,15 @@ package daybreak.abilitywar.game.augment.list;
 
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentManifest;
 import daybreak.abilitywar.game.augment.AugmentContext;
 import daybreak.abilitywar.game.augment.AugmentRarity;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.jetbrains.annotations.NotNull;
 
+@AugmentManifest(key = "swift_start", name = "민첩한 출발", rarity = AugmentRarity.SILVER, description = "이동 속도가 소폭 증가합니다.")
 public class SwiftStart extends AbstractAugment {
-	public SwiftStart() { super("swift_start", "민첩한 출발", AugmentRarity.SILVER, "이동 속도가 소폭 증가합니다."); }
 	@Override protected void onApply(@NotNull AugmentContext context, @NotNull Participant participant) {
 		final AttributeInstance attribute = participant.getPlayer().getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
 		if (attribute != null) attribute.setBaseValue(attribute.getBaseValue() * 1.08);

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/Thornmail.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/Thornmail.java
@@ -1,0 +1,19 @@
+package daybreak.abilitywar.game.augment.list;
+
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentRarity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+
+public class Thornmail extends AbstractAugment {
+	public Thornmail() { super("thornmail", "가시 갑옷", AugmentRarity.GOLD, "근접 피해를 받으면 공격자에게 피해의 20%를 반사합니다."); }
+	@EventHandler(ignoreCancelled = true) public void onDamage(EntityDamageByEntityEvent event) {
+		if (event.getDamager() instanceof Player && event.getEntity() instanceof Player && !(event.getDamager() instanceof Projectile)) {
+			final Participant victim = getParticipant((Player) event.getEntity());
+			if (hasAugment(victim)) ((Player) event.getDamager()).damage(event.getFinalDamage() * 0.20);
+		}
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/Thornmail.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/Thornmail.java
@@ -2,14 +2,15 @@ package daybreak.abilitywar.game.augment.list;
 
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentManifest;
 import daybreak.abilitywar.game.augment.AugmentRarity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 
+@AugmentManifest(key = "thornmail", name = "가시 갑옷", rarity = AugmentRarity.GOLD, description = "근접 피해를 받으면 공격자에게 피해의 20%를 반사합니다.")
 public class Thornmail extends AbstractAugment {
-	public Thornmail() { super("thornmail", "가시 갑옷", AugmentRarity.GOLD, "근접 피해를 받으면 공격자에게 피해의 20%를 반사합니다."); }
 	@EventHandler(ignoreCancelled = true) public void onDamage(EntityDamageByEntityEvent event) {
 		if (event.getDamager() instanceof Player && event.getEntity() instanceof Player && !(event.getDamager() instanceof Projectile)) {
 			final Participant victim = getParticipant((Player) event.getEntity());

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/VampiricBlade.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/VampiricBlade.java
@@ -2,13 +2,14 @@ package daybreak.abilitywar.game.augment.list;
 
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentManifest;
 import daybreak.abilitywar.game.augment.AugmentRarity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 
+@AugmentManifest(key = "vampiric_blade", name = "흡혈 칼날", rarity = AugmentRarity.GOLD, description = "플레이어에게 준 피해의 20%만큼 체력을 회복합니다.")
 public class VampiricBlade extends AbstractAugment {
-	public VampiricBlade() { super("vampiric_blade", "흡혈 칼날", AugmentRarity.GOLD, "플레이어에게 준 피해의 20%만큼 체력을 회복합니다."); }
 	@EventHandler(ignoreCancelled = true) public void onDamage(EntityDamageByEntityEvent event) {
 		if (event.getDamager() instanceof Player && event.getEntity() instanceof Player) {
 			final Participant damager = getParticipant((Player) event.getDamager());

--- a/modules/Plugin/src/daybreak/abilitywar/game/augment/list/VampiricBlade.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/augment/list/VampiricBlade.java
@@ -1,0 +1,18 @@
+package daybreak.abilitywar.game.augment.list;
+
+import daybreak.abilitywar.game.AbstractGame.Participant;
+import daybreak.abilitywar.game.augment.AbstractAugment;
+import daybreak.abilitywar.game.augment.AugmentRarity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+
+public class VampiricBlade extends AbstractAugment {
+	public VampiricBlade() { super("vampiric_blade", "흡혈 칼날", AugmentRarity.GOLD, "플레이어에게 준 피해의 20%만큼 체력을 회복합니다."); }
+	@EventHandler(ignoreCancelled = true) public void onDamage(EntityDamageByEntityEvent event) {
+		if (event.getDamager() instanceof Player && event.getEntity() instanceof Player) {
+			final Participant damager = getParticipant((Player) event.getDamager());
+			if (hasAugment(damager)) heal(damager.getPlayer(), event.getFinalDamage() * 0.20);
+		}
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/list/augment/AugmentWarGame.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/list/augment/AugmentWarGame.java
@@ -1,5 +1,7 @@
 package daybreak.abilitywar.game.list.augment;
 
+import daybreak.abilitywar.ability.event.AbilityCooldownEndEvent;
+import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.GameAliases;
 import daybreak.abilitywar.game.GameManifest;
 import daybreak.abilitywar.game.augment.Augment;
@@ -9,9 +11,24 @@ import daybreak.abilitywar.game.augment.DefaultAugments;
 import daybreak.abilitywar.game.augment.ParticipantAugments;
 import daybreak.abilitywar.game.list.standard.WarGame;
 import org.bukkit.Bukkit;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.projectiles.ProjectileSource;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
 
 @GameManifest(name = "증강 능력자 전쟁", description = {
 		"§f일정 시간마다 참가자가 증강을 획득하는 능력자 전쟁입니다.",
@@ -28,6 +45,7 @@ public class AugmentWarGame extends WarGame {
 	private final ParticipantAugments participantAugments = new ParticipantAugments(this);
 	private final AugmentRegistry augmentRegistry = DefaultAugments.createRegistry();
 	private final AugmentSelection augmentSelection = new AugmentSelection(augmentRegistry, new Random());
+	private final Set<UUID> lastStandUsed = new HashSet<>();
 
 	@Override
 	protected void progressGame(int seconds) {
@@ -49,5 +67,85 @@ public class AugmentWarGame extends WarGame {
 				}
 			}
 		}
+	}
+
+	@EventHandler(ignoreCancelled = true)
+	public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
+		final Participant damager = getDamager(event.getDamager());
+		final Participant victim = event.getEntity() instanceof Player ? getParticipant((Player) event.getEntity()) : null;
+
+		if (damager != null) {
+			if (hasAugment(damager, "glass_cannon")) event.setDamage(event.getDamage() * 1.25);
+			if (hasAugment(damager, "executioner") && event.getEntity() instanceof LivingEntity) {
+				final LivingEntity target = (LivingEntity) event.getEntity();
+				final AttributeInstance maxHealth = target.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+				if (maxHealth != null && target.getHealth() <= maxHealth.getValue() * 0.30) event.setDamage(event.getDamage() * 1.30);
+			}
+			if (hasAugment(damager, "arrow_focus") && event.getDamager() instanceof Projectile) {
+				final double distanceSquared = damager.getPlayer().getLocation().distanceSquared(event.getEntity().getLocation());
+				if (distanceSquared >= 100) event.setDamage(event.getDamage() * 1.35);
+			}
+			if (hasAugment(damager, "vampiric_blade") && victim != null) {
+				heal(damager.getPlayer(), event.getFinalDamage() * 0.20);
+			}
+		}
+
+		if (victim != null) {
+			if (hasAugment(victim, "glass_cannon")) event.setDamage(event.getDamage() * 1.15);
+			if (hasAugment(victim, "thornmail") && damager != null && !(event.getDamager() instanceof Projectile)) {
+				damager.getPlayer().damage(event.getFinalDamage() * 0.20);
+			}
+		}
+	}
+
+	@EventHandler(ignoreCancelled = true)
+	public void onEntityDamage(EntityDamageEvent event) {
+		if (!(event.getEntity() instanceof Player)) return;
+		final Participant participant = getParticipant((Player) event.getEntity());
+		if (participant == null) return;
+		final Player player = participant.getPlayer();
+		if (hasAugment(participant, "last_stand") && !lastStandUsed.contains(player.getUniqueId()) && player.getHealth() - event.getFinalDamage() <= 0) {
+			event.setCancelled(true);
+			lastStandUsed.add(player.getUniqueId());
+			player.setHealth(1.0);
+			player.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 100, 1, true, false));
+			player.addPotionEffect(new PotionEffect(PotionEffectType.INCREASE_DAMAGE, 100, 1, true, false));
+			player.sendMessage("§d[증강] §f최후의 저항이 발동했습니다!");
+			return;
+		}
+		if (hasAugment(participant, "comeback")) {
+			final AttributeInstance maxHealth = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+			if (maxHealth != null && player.getHealth() - event.getFinalDamage() <= maxHealth.getValue() * 0.40) {
+				player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, 80, 0, true, false));
+				player.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 80, 0, true, false));
+			}
+		}
+	}
+
+	@EventHandler
+	public void onAbilityCooldownEnd(AbilityCooldownEndEvent event) {
+		final Participant participant = event.getParticipant();
+		if (participant != null && hasAugment(participant, "ability_echo")) {
+			participant.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 100, 0, true, false));
+			participant.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.INCREASE_DAMAGE, 100, 0, true, false));
+		}
+	}
+
+	private boolean hasAugment(Participant participant, String key) {
+		return participant != null && participantAugments.hasAugment(participant, key);
+	}
+
+	private Participant getDamager(Entity damager) {
+		if (damager instanceof Player) return getParticipant((Player) damager);
+		if (damager instanceof Projectile) {
+			final ProjectileSource shooter = ((Projectile) damager).getShooter();
+			if (shooter instanceof Player) return getParticipant((Player) shooter);
+		}
+		return null;
+	}
+
+	private void heal(Player player, double amount) {
+		final AttributeInstance maxHealth = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+		if (maxHealth != null) player.setHealth(Math.min(maxHealth.getValue(), player.getHealth() + amount));
 	}
 }

--- a/modules/Plugin/src/daybreak/abilitywar/game/list/augment/AugmentWarGame.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/list/augment/AugmentWarGame.java
@@ -1,0 +1,53 @@
+package daybreak.abilitywar.game.list.augment;
+
+import daybreak.abilitywar.game.GameAliases;
+import daybreak.abilitywar.game.GameManifest;
+import daybreak.abilitywar.game.augment.Augment;
+import daybreak.abilitywar.game.augment.AugmentRegistry;
+import daybreak.abilitywar.game.augment.AugmentSelection;
+import daybreak.abilitywar.game.augment.DefaultAugments;
+import daybreak.abilitywar.game.augment.ParticipantAugments;
+import daybreak.abilitywar.game.list.standard.WarGame;
+import org.bukkit.Bukkit;
+
+import java.util.List;
+import java.util.Random;
+
+@GameManifest(name = "증강 능력자 전쟁", description = {
+		"§f일정 시간마다 참가자가 증강을 획득하는 능력자 전쟁입니다.",
+		"",
+		"§a● §f첫 증강은 게임 시작 직후 지급됩니다.",
+		"§a● §f이후 2분마다 생존 참가자에게 새로운 증강이 지급됩니다."
+})
+@GameAliases({"증강", "augment", "augments"})
+public class AugmentWarGame extends WarGame {
+
+	private static final int FIRST_AUGMENT_SECONDS = 18;
+	private static final int AUGMENT_INTERVAL_SECONDS = 120;
+
+	private final ParticipantAugments participantAugments = new ParticipantAugments(this);
+	private final AugmentRegistry augmentRegistry = DefaultAugments.createRegistry();
+	private final AugmentSelection augmentSelection = new AugmentSelection(augmentRegistry, new Random());
+
+	@Override
+	protected void progressGame(int seconds) {
+		super.progressGame(seconds);
+		if (seconds >= FIRST_AUGMENT_SECONDS && (seconds - FIRST_AUGMENT_SECONDS) % AUGMENT_INTERVAL_SECONDS == 0) {
+			grantAugments(seconds);
+		}
+	}
+
+	private void grantAugments(int seconds) {
+		Bukkit.broadcastMessage("§d[증강] §f새로운 증강 라운드가 시작되었습니다. §7(" + seconds + "초)");
+		for (Participant participant : getParticipants()) {
+			if (!getDeathManager().isExcluded(participant.getPlayer())) {
+				final List<Augment> candidates = augmentSelection.roll(participantAugments, participant, 3);
+				if (!candidates.isEmpty()) {
+					final Augment selected = candidates.get(0);
+					selected.apply(participantAugments, participant);
+					participant.getPlayer().sendMessage("§d[증강] §f획득: " + DefaultAugments.format(selected));
+				}
+			}
+		}
+	}
+}

--- a/modules/Plugin/src/daybreak/abilitywar/game/list/augment/AugmentWarGame.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/list/augment/AugmentWarGame.java
@@ -9,9 +9,22 @@ import daybreak.abilitywar.game.augment.DefaultAugments;
 import daybreak.abilitywar.game.augment.ParticipantAugments;
 import daybreak.abilitywar.game.list.standard.WarGame;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 
 @GameManifest(name = "증강 능력자 전쟁", description = {
 		"§f일정 시간마다 참가자가 증강을 획득하는 능력자 전쟁입니다.",
@@ -24,36 +37,131 @@ public class AugmentWarGame extends WarGame {
 
 	private static final int FIRST_AUGMENT_SECONDS = 18;
 	private static final int AUGMENT_INTERVAL_SECONDS = 120;
+	private static final int[] AUGMENT_SLOTS = {11, 13, 15};
 
 	private final ParticipantAugments participantAugments = new ParticipantAugments(this);
 	private final AugmentRegistry augmentRegistry = DefaultAugments.createRegistry();
 	private final AugmentSelection augmentSelection = new AugmentSelection(augmentRegistry, new Random());
+	private final Map<UUID, List<Augment>> pendingChoices = new HashMap<>();
 
 	@Override
 	protected void progressGame(int seconds) {
 		super.progressGame(seconds);
 		if (seconds >= FIRST_AUGMENT_SECONDS && (seconds - FIRST_AUGMENT_SECONDS) % AUGMENT_INTERVAL_SECONDS == 0) {
-			grantAugments(seconds);
+			grantAugmentChoices(seconds);
 		}
 	}
 
-	private void grantAugments(int seconds) {
+	private void grantAugmentChoices(int seconds) {
 		Bukkit.broadcastMessage("§d[증강] §f새로운 증강 라운드가 시작되었습니다. §7(" + seconds + "초)");
 		for (Participant participant : getParticipants()) {
 			if (!getDeathManager().isExcluded(participant.getPlayer())) {
 				final List<Augment> candidates = augmentSelection.roll(participantAugments, participant, 3);
 				if (!candidates.isEmpty()) {
-					final Augment selected = candidates.get(0);
-					selected.apply(participantAugments, participant);
-					participant.getPlayer().sendMessage("§d[증강] §f획득: " + DefaultAugments.format(selected));
+					pendingChoices.put(participant.getPlayer().getUniqueId(), candidates);
+					participant.getPlayer().sendMessage("§d[증강] §f선택 가능한 증강이 도착했습니다. §7/aw augment §f명령어로 다시 열 수 있습니다.");
+					openAugmentGUI(participant.getPlayer());
+				} else {
+					participant.getPlayer().sendMessage("§d[증강] §7현재 선택 가능한 증강이 없습니다.");
 				}
 			}
 		}
 	}
 
+	public void openAugmentGUI(Player player) {
+		final Participant participant = getParticipant(player);
+		if (participant == null || getDeathManager().isExcluded(player)) {
+			player.sendMessage("§d[증강] §c증강을 선택할 수 없는 상태입니다.");
+			return;
+		}
+		final List<Augment> choices = pendingChoices.get(player.getUniqueId());
+		if (choices == null || choices.isEmpty()) {
+			player.sendMessage("§d[증강] §7선택 대기 중인 증강이 없습니다.");
+			return;
+		}
+		final AugmentInventoryHolder holder = new AugmentInventoryHolder(player.getUniqueId());
+		final Inventory inventory = Bukkit.createInventory(holder, 27, "§0§l증강 선택");
+		holder.setInventory(inventory);
+		for (int i = 0; i < choices.size() && i < AUGMENT_SLOTS.length; i++) {
+			inventory.setItem(AUGMENT_SLOTS[i], createIcon(choices.get(i)));
+		}
+		player.openInventory(inventory);
+	}
+
+	private ItemStack createIcon(Augment augment) {
+		final ItemStack item = new ItemStack(Material.ENCHANTED_BOOK);
+		final ItemMeta meta = item.getItemMeta();
+		if (meta != null) {
+			meta.setDisplayName(augment.getRarity().format("[" + augment.getRarity().getDisplayName() + "] ") + "§f" + augment.getDisplayName());
+			final List<String> lore = new ArrayList<>();
+			lore.add("§7" + augment.getDescription());
+			lore.add("");
+			lore.add("§e클릭해서 이 증강을 선택합니다.");
+			meta.setLore(lore);
+			item.setItemMeta(meta);
+		}
+		return item;
+	}
+
+	@EventHandler
+	public void onInventoryClick(InventoryClickEvent event) {
+		if (!(event.getInventory().getHolder() instanceof AugmentInventoryHolder)) return;
+		event.setCancelled(true);
+		if (!(event.getWhoClicked() instanceof Player)) return;
+		final Player player = (Player) event.getWhoClicked();
+		if (!((AugmentInventoryHolder) event.getInventory().getHolder()).isOwner(player.getUniqueId())) return;
+		final List<Augment> choices = pendingChoices.get(player.getUniqueId());
+		if (choices == null) {
+			player.closeInventory();
+			return;
+		}
+		for (int i = 0; i < AUGMENT_SLOTS.length && i < choices.size(); i++) {
+			if (event.getRawSlot() == AUGMENT_SLOTS[i]) {
+				final Augment selected = choices.get(i);
+				pendingChoices.remove(player.getUniqueId());
+				selected.apply(participantAugments, getParticipant(player));
+				player.sendMessage("§d[증강] §f획득: " + DefaultAugments.format(selected));
+				player.closeInventory();
+				return;
+			}
+		}
+	}
+
+	@EventHandler
+	public void onInventoryClose(InventoryCloseEvent event) {
+		if (event.getInventory().getHolder() instanceof AugmentInventoryHolder
+				&& ((AugmentInventoryHolder) event.getInventory().getHolder()).isOwner(event.getPlayer().getUniqueId())
+				&& pendingChoices.containsKey(event.getPlayer().getUniqueId())) {
+			event.getPlayer().sendMessage("§d[증강] §7아직 증강을 선택하지 않았습니다. §f/aw augment §7명령어로 다시 열 수 있습니다.");
+		}
+	}
+
 	@Override
 	protected void onEnd() {
+		pendingChoices.clear();
 		augmentRegistry.unregisterListeners();
 		super.onEnd();
+	}
+
+	private static class AugmentInventoryHolder implements InventoryHolder {
+		private final UUID playerId;
+		private Inventory inventory;
+
+		private AugmentInventoryHolder(UUID playerId) {
+			this.playerId = playerId;
+		}
+
+		private void setInventory(Inventory inventory) {
+			this.inventory = inventory;
+		}
+
+		private boolean isOwner(UUID playerId) {
+			return this.playerId.equals(playerId);
+		}
+
+		@Override
+		public Inventory getInventory() {
+			return inventory;
+		}
 	}
 }

--- a/modules/Plugin/src/daybreak/abilitywar/game/list/augment/AugmentWarGame.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/list/augment/AugmentWarGame.java
@@ -1,7 +1,5 @@
 package daybreak.abilitywar.game.list.augment;
 
-import daybreak.abilitywar.ability.event.AbilityCooldownEndEvent;
-import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.GameAliases;
 import daybreak.abilitywar.game.GameManifest;
 import daybreak.abilitywar.game.augment.Augment;
@@ -11,24 +9,9 @@ import daybreak.abilitywar.game.augment.DefaultAugments;
 import daybreak.abilitywar.game.augment.ParticipantAugments;
 import daybreak.abilitywar.game.list.standard.WarGame;
 import org.bukkit.Bukkit;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.attribute.AttributeInstance;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Projectile;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
-import org.bukkit.projectiles.ProjectileSource;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
-import java.util.Set;
-import java.util.UUID;
 
 @GameManifest(name = "증강 능력자 전쟁", description = {
 		"§f일정 시간마다 참가자가 증강을 획득하는 능력자 전쟁입니다.",
@@ -45,7 +28,6 @@ public class AugmentWarGame extends WarGame {
 	private final ParticipantAugments participantAugments = new ParticipantAugments(this);
 	private final AugmentRegistry augmentRegistry = DefaultAugments.createRegistry();
 	private final AugmentSelection augmentSelection = new AugmentSelection(augmentRegistry, new Random());
-	private final Set<UUID> lastStandUsed = new HashSet<>();
 
 	@Override
 	protected void progressGame(int seconds) {
@@ -69,83 +51,9 @@ public class AugmentWarGame extends WarGame {
 		}
 	}
 
-	@EventHandler(ignoreCancelled = true)
-	public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
-		final Participant damager = getDamager(event.getDamager());
-		final Participant victim = event.getEntity() instanceof Player ? getParticipant((Player) event.getEntity()) : null;
-
-		if (damager != null) {
-			if (hasAugment(damager, "glass_cannon")) event.setDamage(event.getDamage() * 1.25);
-			if (hasAugment(damager, "executioner") && event.getEntity() instanceof LivingEntity) {
-				final LivingEntity target = (LivingEntity) event.getEntity();
-				final AttributeInstance maxHealth = target.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-				if (maxHealth != null && target.getHealth() <= maxHealth.getValue() * 0.30) event.setDamage(event.getDamage() * 1.30);
-			}
-			if (hasAugment(damager, "arrow_focus") && event.getDamager() instanceof Projectile) {
-				final double distanceSquared = damager.getPlayer().getLocation().distanceSquared(event.getEntity().getLocation());
-				if (distanceSquared >= 100) event.setDamage(event.getDamage() * 1.35);
-			}
-			if (hasAugment(damager, "vampiric_blade") && victim != null) {
-				heal(damager.getPlayer(), event.getFinalDamage() * 0.20);
-			}
-		}
-
-		if (victim != null) {
-			if (hasAugment(victim, "glass_cannon")) event.setDamage(event.getDamage() * 1.15);
-			if (hasAugment(victim, "thornmail") && damager != null && !(event.getDamager() instanceof Projectile)) {
-				damager.getPlayer().damage(event.getFinalDamage() * 0.20);
-			}
-		}
-	}
-
-	@EventHandler(ignoreCancelled = true)
-	public void onEntityDamage(EntityDamageEvent event) {
-		if (!(event.getEntity() instanceof Player)) return;
-		final Participant participant = getParticipant((Player) event.getEntity());
-		if (participant == null) return;
-		final Player player = participant.getPlayer();
-		if (hasAugment(participant, "last_stand") && !lastStandUsed.contains(player.getUniqueId()) && player.getHealth() - event.getFinalDamage() <= 0) {
-			event.setCancelled(true);
-			lastStandUsed.add(player.getUniqueId());
-			player.setHealth(1.0);
-			player.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 100, 1, true, false));
-			player.addPotionEffect(new PotionEffect(PotionEffectType.INCREASE_DAMAGE, 100, 1, true, false));
-			player.sendMessage("§d[증강] §f최후의 저항이 발동했습니다!");
-			return;
-		}
-		if (hasAugment(participant, "comeback")) {
-			final AttributeInstance maxHealth = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-			if (maxHealth != null && player.getHealth() - event.getFinalDamage() <= maxHealth.getValue() * 0.40) {
-				player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, 80, 0, true, false));
-				player.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 80, 0, true, false));
-			}
-		}
-	}
-
-	@EventHandler
-	public void onAbilityCooldownEnd(AbilityCooldownEndEvent event) {
-		final Participant participant = event.getParticipant();
-		if (participant != null && hasAugment(participant, "ability_echo")) {
-			participant.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 100, 0, true, false));
-			participant.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.INCREASE_DAMAGE, 100, 0, true, false));
-		}
-	}
-
-	private boolean hasAugment(Participant participant, String key) {
-		return participant != null && participantAugments.hasAugment(participant, key);
-	}
-
-	private Participant getDamager(Entity damager) {
-		if (damager instanceof Player) return getParticipant((Player) damager);
-		if (damager instanceof Projectile) {
-			final ProjectileSource shooter = ((Projectile) damager).getShooter();
-			if (shooter instanceof Player) return getParticipant((Player) shooter);
-		}
-		return null;
-	}
-
-	private void heal(Player player, double amount) {
-		final AttributeInstance maxHealth = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-		if (maxHealth != null) player.setHealth(Math.min(maxHealth.getValue(), player.getHealth() + amount));
+	@Override
+	protected void onEnd() {
+		augmentRegistry.unregisterListeners();
+		super.onEnd();
 	}
 }

--- a/modules/Plugin/src/daybreak/abilitywar/game/manager/GameFactory.java
+++ b/modules/Plugin/src/daybreak/abilitywar/game/manager/GameFactory.java
@@ -11,6 +11,7 @@ import daybreak.abilitywar.game.Category.GameCategory;
 import daybreak.abilitywar.game.GameAliases;
 import daybreak.abilitywar.game.GameManifest;
 import daybreak.abilitywar.game.TeamSupport;
+import daybreak.abilitywar.game.list.augment.AugmentWarGame;
 import daybreak.abilitywar.game.list.baskinrobbins.BaskinRobbins;
 import daybreak.abilitywar.game.list.blind.BlindAbilityWar;
 import daybreak.abilitywar.game.list.changeability.ChangeAbilityWar;
@@ -63,6 +64,7 @@ public class GameFactory {
 	static {
 		registerMode(StandardGame.class);
 		registerMode(WarGame.class);
+		registerMode(AugmentWarGame.class);
 		registerMode(ChangeAbilityWar.class);
 		registerMode(SummerVacation.class);
 		registerMode(MixGame.class);


### PR DESCRIPTION
### Motivation
- Introduce a modular "augment" system to provide selectable, persistent player buffs and diversify gameplay.
- Provide a registry and rarity-based selection mechanism to present randomized augment options to participants. 
- Add a new game mode that periodically grants augments to surviving participants.

### Description
- Added the `Augment` interface and base implementation `AbstractAugment` to represent selectable augment effects and availability rules. 
- Implemented augment infrastructure including `AugmentRarity`, `AugmentRegistry`, `AugmentSelection`, `AugmentContext`, and `ParticipantAugments` for storage, weighting, and selection logic. 
- Added `DefaultAugments` with example augment implementations (`extra_heart`, `swift_start`, `battle_trance`, `prismatic_body`) and formatting utilities. 
- Added the `AugmentWarGame` game mode and registered it in `GameFactory` so it is available alongside existing modes via `registerMode`.

### Testing
- Built the plugin to ensure the codebase compiles successfully (no compilation errors reported). 
- No automated unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a528ac80e30832f92255a1f9a9c254a)